### PR TITLE
Enable observability logs configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,3 +9,7 @@ compatibility_flags = ["nodejs_compat"]
 # Static assets configuration
 [assets]
 directory = "./src/static"
+
+# Observability configuration
+[observability.logs]
+enabled = false


### PR DESCRIPTION
## Summary
Add observability logs configuration to wrangler.toml to ensure consistent logging settings across deployments.

## Changes
- Add `[observability.logs]` section with `enabled = false`
- Ensures logs configuration is explicit and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)