### PR TITLE
Enable observability logs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,4 +9,4 @@ directory = "./src/static"
 
 # Observability configuration
 [observability.logs]
-enabled = false
+enabled = true


### PR DESCRIPTION
## Summary
Enable observability logging by setting `enabled = true` in wrangler.toml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)