### PR TITLE
Fix tracks endpoint for self-hosted MP3 files

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -43,10 +43,18 @@ app.get('/api/tracks/:trackUrl{.+}', async (c) => {
       return c.json({ error: 'Only MP3 URLs are supported' }, 400);
     }
 
-    const response = await fetch(trackUrl, { method: 'HEAD' });
+    // Check if it's a self-hosted file (same domain)
+    const requestHost = new URL(c.req.url).host;
+    const trackUrlObj = new URL(trackUrl);
+    const isSelfHosted = trackUrlObj.host === requestHost;
 
-    if (!response.ok) {
-      throw new Error('Failed to fetch MP3');
+    // For self-hosted files, skip the HEAD check (they're served by assets)
+    // For external files, verify they exist
+    if (!isSelfHosted) {
+      const response = await fetch(trackUrl, { method: 'HEAD' });
+      if (!response.ok) {
+        throw new Error('Failed to fetch MP3');
+      }
     }
 
     return c.json({


### PR DESCRIPTION
## Summary
Fix the `/api/tracks` endpoint failing when checking self-hosted MP3 files.

## Problem
The endpoint was doing a HEAD request to verify the MP3 exists, but this created a circular fetch when the file is hosted on the same domain. Workers can't fetch their own static assets via HTTP because they're served by Wrangler's asset system, not through the fetch handler.

Error: `https://dweetplayer.net/api/tracks/https%3A%2F%2Fdweetplayer.net%2Ftrack.mp3` returned 500

## Solution
- Detect if the MP3 URL is on the same domain as the request
- Skip HEAD validation for self-hosted files (they're served by assets, so we trust they exist)
- Still validate external MP3 URLs with HEAD request

🤖 Generated with [Claude Code](https://claude.com/claude-code)