### PR TITLE
Fix /demo/* route circular fetch

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -127,8 +127,9 @@ app.get('/api/proxy/:url{.+}', async (c) => {
 
 // SPA route - serve index.html for /demo/* paths (for client-side routing)
 app.get('/demo/*', async (c) => {
-  // Fetch the index.html from assets
-  return c.html(await (await fetch(new URL('/index.html', c.req.url))).text());
+  // Fetch the index.html from the assets binding
+  const assetResponse = await c.env.ASSETS.fetch(new URL('/index.html', c.req.url));
+  return c.html(await assetResponse.text());
 });
 
 // Note: Other static files (HTML, CSS, JS) are automatically served by Wrangler's asset handling


### PR DESCRIPTION
## Summary
Fix 522 error when refreshing /demo/* URLs by using the ASSETS binding instead of fetch().

## Changes
- Use `c.env.ASSETS.fetch()` to retrieve index.html from static assets
- Prevents circular fetch that was causing 522 errors in production

## Problem
The `/demo/*` route was using `fetch(new URL('/index.html', c.req.url))` which caused the worker to try to HTTP-fetch its own asset, resulting in a circular fetch and 522 error.

## Solution
Use the ASSETS binding (`c.env.ASSETS.fetch()`) which properly accesses static files without HTTP requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)