### PR TITLE
Document MP3 metadata limitation for self-hosted files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ enabled = true
 
 3. **CORS:** The proxy endpoint exists solely to bypass CORS for external MP3 files. Self-hosted files don't need it.
 
+4. **MP3 Metadata for Self-Hosted Files:** ID3 metadata extraction fails for self-hosted MP3 files due to circular fetch issues (worker cannot fetch from itself). Only external MP3 files can have their metadata extracted. Self-hosted files show "Unknown by Unknown". **TODO:** Consider client-side metadata extraction or pre-extracting metadata at build time.
+
 ## Dependencies
 
 **Runtime:**


### PR DESCRIPTION
## Summary
Document known issue: ID3 metadata extraction doesn't work for self-hosted MP3 files due to circular fetch restrictions.

## Issue
The `/api/tracks` endpoint attempts to fetch MP3 files to extract ID3 metadata, but Cloudflare Workers cannot HTTP-fetch from their own domain. This causes self-hosted MP3 files to fail metadata extraction and display "Unknown by Unknown".

## Status
- ✅ Works: External MP3 files (metadata extracted successfully)
- ❌ Fails: Self-hosted MP3 files (circular fetch error)

## Potential Solutions
1. Client-side metadata extraction (parse ID3 tags in browser)
2. Build-time metadata extraction (pre-extract and embed in static JSON)
3. Use R2 storage or external CDN for MP3 files

This is a documentation-only change to make the limitation clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)